### PR TITLE
feature: cache (t2t supported)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+tests/
 
 # Translations
 *.mo

--- a/eval_anything/pipeline/base_task.py
+++ b/eval_anything/pipeline/base_task.py
@@ -14,6 +14,10 @@ from eval_anything.evaluate_tools.t2t_tools import *
 from eval_anything.evaluate_tools.metrics import MetricCalculator
 from eval_anything.utils.utils import UUIDGenerator, read_cfgs_from_yaml, update_dict, custom_cfgs_to_dict, BENCHMARK_MODALITY_MAP
 import importlib
+import json
+import hashlib
+from vllm.sequence import Logprob
+from vllm.sequence import RequestOutput
 
 
 class BaseTask(ABC):
@@ -21,7 +25,7 @@ class BaseTask(ABC):
         # TODO 初始化数据集、模型、logger、任务列表
         self.logger = EvalLogger('Evaluation')
         self.eval_cfgs, self.model_cfgs, self.infer_cfgs = self.get_overall_configs(overall_cfgs_name, **kwargs)
-        self.save_cache = True if self.eval_cfgs["cache_dir"] else False
+        self.enable_cache = True if self.eval_cfgs["cache_dir"] else False
         self.output_path = self.eval_cfgs["output_dir"]
         self.model = self.load_model(self.model_cfgs, self.infer_cfgs)
     
@@ -119,7 +123,7 @@ class BaseTask(ABC):
         input_data_batches = [input_list[i:i+batch_size] for i in range(0, len(input_list), batch_size)]
         inference_outputs = []
         for input_data_batch in input_data_batches:
-            if self.save_cache:
+            if self.enable_cache:
                 cache_path, cache_exist = self.get_cache_path(self.model_cfgs, input_data_batch)
                 if cache_exist:
                     inference_outputs.extend(self.load_cache(os.path.join(self.eval_cfgs["cache_dir"], cache_path)))
@@ -178,8 +182,7 @@ class BaseTask(ABC):
         self.save_single_result(self.output_path, result)
         return result
     
-    def get_cache_path(self, model_cfgs: dict, input_data: list[InferenceInput]):
-        # TODO 获取cache路径并检查是否存在
+    def get_cache_path(self, model_cfgs: dict, input_data: list[InferenceInput]) -> tuple[str, bool]:
         """Get cache path and check if it exists
         Args:
             model_cfgs (dict): model configs
@@ -189,26 +192,203 @@ class BaseTask(ABC):
             cache_path (str): cache path
             cache_exist (bool): whether the cache exists
         """
-    
+        # Create a unique identifier based on model config and input data
+        model_name = model_cfgs.get('model_name_or_path', 'unknown_model')
+        
+        # Use the built-in __repr__ method to get consistent string representation
+        input_strings = [repr(data) for data in input_data]
+        
+        # Sort for consistency and create hash
+        input_strings.sort()
+        inputs_hash = hashlib.md5(''.join(input_strings).encode()).hexdigest()
+        
+        if model_cfgs['model_type'] == 'LM':
+            # Use JSON for pure text-based outputs
+            cache_path = os.path.join(model_name, f"{inputs_hash}.json")
+        elif model_cfgs['model_type'] == 'MM':
+            task_type = model_cfgs.get('task_type', '').lower()
+            if task_type in ['t2i', 'multi']:
+                # Use Parquet for tasks involving images
+                cache_path = os.path.join(model_name, f"{inputs_hash}.parquet")
+            elif task_type in ['i2t', 'vqa']:
+                # Use JSON for text-only outputs in MM tasks
+                cache_path = os.path.join(model_name, f"{inputs_hash}.json")
+            elif task_type in ['t2a', 'a2t', 'asr', 'tts']:
+                # Use HDF5 for audio-related tasks
+                cache_path = os.path.join(model_name, f"{inputs_hash}.h5")
+            else:
+                raise NotImplementedError(
+                    f"MM task type {task_type} is not supported."
+                )
+        else:
+            raise NotImplementedError(
+                f"Model type {model_cfgs['model_type']} is not supported."
+            )   
+        
+        cache_exist = os.path.exists(os.path.join(self.eval_cfgs["cache_dir"], cache_path))
+        return cache_path, cache_exist
+
     def save_cache(self, cache_path: str, inference_outputs: list[InferenceOutput]):
-        # TODO 将中间结果保存为cache
         """Save inference outputs as cache
         Args:
             cache_path (str): cache path
             inference_outputs (list[InferenceOutput]): inference outputs
+        Returns:
+            None
         """
-        pass
-    
-    def load_cache(self, cache_path: str):
-        # TODO 从cache中加载中间结果
+        # If the cache already exists, raise error
+        if os.path.exists(cache_path):
+            raise FileExistsError(
+                f"Cache file {cache_path} already exists."
+            )      
+        
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+
+        file_format = os.path.splitext(cache_path)[1].lower()
+        
+        cache_data = []
+        for output in inference_outputs:
+            # Create base cache entry with required fields
+            cache_entry = {
+                'task': output.task,
+                'uuid': output.uuid,
+                'response': output.response,
+                'engine': output.engine
+            }
+        
+            # Add optional fields if they exist
+            if output.response_token_ids is not None:
+                cache_entry['response_token_ids'] = output.response_token_ids
+        
+            # Serialize response_logprobs (PromptLogprobs)
+            if output.response_logprobs is not None:
+                cache_entry['response_logprobs'] = [
+                    None if logprob_dict is None else {
+                        str(token_id): {
+                            'logprob': logprob.logprob,
+                            'rank': logprob.rank,
+                            'decoded_token': logprob.decoded_token
+                        } for token_id, logprob in logprob_dict.items()
+                    }
+                    for logprob_dict in output.response_logprobs
+                ]
+            # Serialize raw_output (RequestOutput)
+            if output.raw_output is not None:
+                cache_entry['raw_output'] = {
+                    'request_id': output.raw_output.request_id,
+                    'prompt': output.raw_output.prompt,
+                    'prompt_token_ids': output.raw_output.prompt_token_ids,
+                    'prompt_logprobs': [
+                        None if logprob_dict is None else {
+                            str(token_id): {
+                                'logprob': logprob.logprob,
+                                'rank': logprob.rank,
+                                'decoded_token': logprob.decoded_token
+                            } for token_id, logprob in logprob_dict.items()
+                        }   
+                        for logprob_dict in (output.raw_output.prompt_logprobs or [])
+                    ],
+                    'outputs': [
+                        {
+                            'text': output.text,
+                            'token_ids': output.token_ids,
+                            'cumulative_logprob': output.cumulative_logprob,
+                            'logprobs': output.logprobs,
+                            'finish_reason': output.finish_reason
+                        } for output in output.raw_output.outputs
+                    ],
+                    'finished': output.raw_output.finished
+                }
+        
+            cache_data.append(cache_entry)
+        
+        if file_format == '.json':
+            with open(cache_path, 'w', encoding='utf-8') as f:
+                json.dump(cache_data, f, ensure_ascii=False, indent=2)  
+        else:
+            raise NotImplementedError(
+                f"Cache format {file_format} is not supported."
+            )
+
+        # TODO MultiModalData, need to adapt InferenceOutput
+        # TODO Other cache file format than json, such as parquet, hdf5, etc.
+
+    def load_cache(self, cache_path: str) -> list[InferenceOutput]:
         """Load inference outputs from cache
         Args:
             cache_path (str): cache path
             
         Returns:
-            inference_outputs (list[InferenceOutput]): inference outputs
+            inference_outputs (list[InferenceOutput]): inference outputs    
         """
-        pass
+        file_format = os.path.splitext(cache_path)[1].lower()
+        if file_format == '.json':
+            with open(cache_path, 'r', encoding='utf-8') as f:
+                cache_data = json.load(f)
+        else:
+            raise NotImplementedError(
+                f"Cache format {file_format} is not supported."
+            )   
+        
+        inference_outputs = []
+        for data in cache_data:
+            # Deserialize response_logprobs if present
+            response_logprobs = None
+            if 'response_logprobs' in data:
+                response_logprobs = [
+                    None if logprob_dict is None else {
+                        int(token_id): Logprob(
+                            logprob=info['logprob'],
+                            rank=info['rank'],
+                            decoded_token=info['decoded_token']
+                        ) for token_id, info in logprob_dict.items()
+                    }
+                    for logprob_dict in data['response_logprobs']
+                ]
+            
+            # Deserialize raw_output if present
+            raw_output = None
+            if 'raw_output' in data:
+                raw_data = data['raw_output']
+                prompt_logprobs = None
+                if raw_data.get('prompt_logprobs'):
+                    prompt_logprobs = [
+                        None if logprob_dict is None else {
+                            int(token_id): Logprob(
+                                logprob=info['logprob'],
+                                rank=info['rank'],
+                                decoded_token=info['decoded_token']
+                            ) for token_id, info in logprob_dict.items()
+                        }
+                        for logprob_dict in raw_data['prompt_logprobs']
+                    ]
+                
+                raw_output = RequestOutput(
+                    request_id=raw_data['request_id'],
+                    prompt=raw_data['prompt'],
+                    prompt_token_ids=raw_data['prompt_token_ids'],
+                    prompt_logprobs=prompt_logprobs,
+                    outputs=raw_data['outputs'],
+                    finished=raw_data['finished']
+                )
+            
+            # Create InferenceOutput with all fields
+            output = InferenceOutput(
+                task=data['task'],
+                uuid=data['uuid'],
+                response=data['response'],
+                engine=data['engine'],
+                response_token_ids=data.get('response_token_ids'),
+                response_logprobs=response_logprobs,
+                raw_output=raw_output
+            )
+            inference_outputs.append(output)
+        
+        # TODO MultiModalData, need to adapt InferenceOutput
+        # TODO Other cache file format than json, such as parquet, hdf5, etc.
+
+        return inference_outputs
+        
     
     def shutdown_model(self):
         # TODO 关闭模型

--- a/eval_anything/utils/cache_manager.py
+++ b/eval_anything/utils/cache_manager.py
@@ -2,15 +2,14 @@
 Cache management utilities for storing and retrieving inference results.
 
 Engine 解耦：
-- 不同的 engine 产生的 InferenceOutput 有不同的数据结构和存储方式
+- 不同的 engine 产生的 raw output 有不同的数据结构
 - 因此需要为每个 engine 提供一个专门的 serializer
-- 在 save 方法中，根据 engine 选择相应的 serializer
-- 在 load 方法中，根据 engine 选择相应的 serializer
 
 MultiModality 
 - 不同的 modality 有不同的 serializer
-- 在 save 方法中，根据 modality 选择相应的 serializer
-- 在 load 方法中，根据 modality 选择相应的 serializer
+
+- 在 Serializer 和 Deserializer 中, 灵活组合不同engine和modality
+- CacheManager 只负责路径生成、存储和读取的逻辑
 """
 
 import os

--- a/eval_anything/utils/cache_manager.py
+++ b/eval_anything/utils/cache_manager.py
@@ -15,7 +15,8 @@ MultiModality
 import os
 import json
 import hashlib
-from typing import List, Tuple
+from typing import List, Tuple, Optional
+import logging
 
 from eval_anything.utils.data_type import InferenceInput, InferenceOutput
 from eval_anything.utils.serializers import SerializerRegistry
@@ -24,7 +25,19 @@ class CacheManager:
     """Cache manager for inference results"""
     
     def __init__(self, cache_dir: str):
+        """Initialize cache manager
+        
+        Args:
+            cache_dir: Directory path for caching results
+            
+        Raises:
+            ValueError: If cache_dir is invalid or cannot be created
+        """
         self.cache_dir = cache_dir
+        try:
+            os.makedirs(cache_dir, exist_ok=True)
+        except (OSError, PermissionError) as e:
+            raise ValueError(f"Failed to create or access cache directory {cache_dir}: {e}")
         
     def get_cache_path(self, model_cfg: dict, inputs: List[InferenceInput]) -> Tuple[str, bool]:
         """Get cache path and check if exists
@@ -41,12 +54,15 @@ class CacheManager:
         # Create deterministic string representation of inputs
         input_strings = []
         for data in inputs:
-            # Include task and text
-            input_str = f"task:{data.task}|text:{data.text}"
+            # Include task and text (if present)
+            input_str = f"task:{data.task}"
+            if data.text is not None:
+                input_str += f"|text:{data.text}"
             
             # Include UUID if present
             if data.uuid:
-                uuid_str = '|'.join(f"{k}:{v}" for k, v in sorted(data.uuid.items()))
+                uuid_str = '|'.join(f"{k}:{self._normalize_value(v)}" 
+                                  for k, v in sorted(data.uuid.items()))
                 input_str += f"|uuid:{uuid_str}"
                 
             # Include multimodal data if present
@@ -65,13 +81,33 @@ class CacheManager:
         
         return cache_path, os.path.exists(cache_path)
 
+    def _normalize_value(self, value: any) -> str:
+        """Normalize values for consistent hashing
+        
+        Handles floating point numbers by rounding to 6 decimal places
+        """
+        if isinstance(value, float):
+            return f"{value:.6f}"
+        return str(value)
+
     def save(self, cache_path: str, outputs: List[InferenceOutput]) -> None:
-        """Save outputs to cache"""
+        """Save outputs to cache
+        
+        Args:
+            cache_path: Path to save cache file
+            outputs: List of inference outputs to cache
+            
+        Raises:
+            ValueError: If serializer is not found for an output's engine
+        """
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
         
         cache_data = []
         for output in outputs:
             engine_serializer = SerializerRegistry.get(output.engine)
+            if engine_serializer is None:
+                raise ValueError(f"No serializer found for engine: {output.engine}")
+                
             cache_entry = engine_serializer.serialize(output)
             cache_data.append(cache_entry)
             
@@ -79,13 +115,31 @@ class CacheManager:
             json.dump(cache_data, f, ensure_ascii=False, indent=2)
 
     def load(self, cache_path: str) -> List[InferenceOutput]:
-        """Load outputs from cache"""
+        """Load outputs from cache
+        
+        Args:
+            cache_path: Path to cache file
+            
+        Returns:
+            List of deserialized inference outputs
+            
+        Raises:
+            ValueError: If serializer is not found for cached output's engine
+        """
         with open(cache_path, 'r', encoding='utf-8') as f:
             cache_data = json.load(f)
         
         outputs = []
         for data in cache_data:
-            serializer = SerializerRegistry.get(data['engine'])
+            engine = data.get('engine')
+            if not engine:
+                logging.warning(f"Skipping cache entry without engine field: {data}")
+                continue
+                
+            serializer = SerializerRegistry.get(engine)
+            if serializer is None:
+                raise ValueError(f"No serializer found for engine: {engine}")
+                
             output = serializer.deserialize(data)
             outputs.append(output)
             

--- a/eval_anything/utils/cache_manager.py
+++ b/eval_anything/utils/cache_manager.py
@@ -1,0 +1,93 @@
+"""
+Cache management utilities for storing and retrieving inference results.
+
+Engine 解耦：
+- 不同的 engine 产生的 InferenceOutput 有不同的数据结构和存储方式
+- 因此需要为每个 engine 提供一个专门的 serializer
+- 在 save 方法中，根据 engine 选择相应的 serializer
+- 在 load 方法中，根据 engine 选择相应的 serializer
+
+MultiModality 
+- 不同的 modality 有不同的 serializer
+- 在 save 方法中，根据 modality 选择相应的 serializer
+- 在 load 方法中，根据 modality 选择相应的 serializer
+"""
+
+import os
+import json
+import hashlib
+from typing import List, Tuple
+
+from eval_anything.utils.data_type import InferenceInput, InferenceOutput
+from eval_anything.utils.serializers import SerializerRegistry
+
+class CacheManager:
+    """Cache manager for inference results"""
+    
+    def __init__(self, cache_dir: str):
+        self.cache_dir = cache_dir
+        
+    def get_cache_path(self, model_cfg: dict, inputs: List[InferenceInput]) -> Tuple[str, bool]:
+        """Get cache path and check if exists
+        
+        Args:
+            model_cfg: Model configuration dictionary
+            inputs: List of inference inputs
+            
+        Returns:
+            Tuple of (cache_path, exists_flag)
+        """
+        model_name = model_cfg.get('model_name', 'unknown_model')
+        
+        # Create deterministic string representation of inputs
+        input_strings = []
+        for data in inputs:
+            # Include task and text
+            input_str = f"task:{data.task}|text:{data.text}"
+            
+            # Include UUID if present
+            if data.uuid:
+                uuid_str = '|'.join(f"{k}:{v}" for k, v in sorted(data.uuid.items()))
+                input_str += f"|uuid:{uuid_str}"
+                
+            # Include multimodal data if present
+            if data.mm_data:
+                urls = [item.url for item in data.mm_data]
+                input_str += f"|urls:{','.join(urls)}"
+                
+            input_strings.append(input_str)
+        
+        # Sort for deterministic ordering
+        input_strings.sort()
+        
+        # Create hash from concatenated string
+        inputs_hash = hashlib.md5(''.join(input_strings).encode()).hexdigest()
+        cache_path = os.path.join(self.cache_dir, model_name, f"{inputs_hash}.json")
+        
+        return cache_path, os.path.exists(cache_path)
+
+    def save(self, cache_path: str, outputs: List[InferenceOutput]) -> None:
+        """Save outputs to cache"""
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        
+        cache_data = []
+        for output in outputs:
+            engine_serializer = SerializerRegistry.get(output.engine)
+            cache_entry = engine_serializer.serialize(output)
+            cache_data.append(cache_entry)
+            
+        with open(cache_path, 'w', encoding='utf-8') as f:
+            json.dump(cache_data, f, ensure_ascii=False, indent=2)
+
+    def load(self, cache_path: str) -> List[InferenceOutput]:
+        """Load outputs from cache"""
+        with open(cache_path, 'r', encoding='utf-8') as f:
+            cache_data = json.load(f)
+        
+        outputs = []
+        for data in cache_data:
+            serializer = SerializerRegistry.get(data['engine'])
+            output = serializer.deserialize(data)
+            outputs.append(output)
+            
+        return outputs

--- a/eval_anything/utils/data_type.py
+++ b/eval_anything/utils/data_type.py
@@ -77,14 +77,28 @@ class InferenceInput:
         self,
         task: str,
         text: str,
-        urls: List[str] | str | None,
+        urls: List[str] | str | None = None,
         data_files = None,
         uuid: Dict[str, str] = None
     ):
         self.task = task
         self.text = text
+        self.uuid = uuid or {}
+
+        # FIXME: Decide data structure of urls
+        if isinstance(urls, str):
+            urls = [urls]
+        urls = urls or []
+
+        # FIXME: Decide data structure of data_files
+        if data_files is None:
+            data_files = [None] * len(urls)
+        elif isinstance(data_files, (str, bytes, PIL.Image.Image)):
+            data_files = [data_files]
+
+        # Create MultiModalData objects
+        # FIXME: mm_data: List[MultiModalData] or MultiModalData ?
         self.mm_data = [MultiModalData(url, file) for url, file in zip(urls, data_files)]
-        self.uuid = uuid
 
     def __repr__(self):
         return f'InferenceInput(' f'text={self.text!r}),' f'mm_data={self.mm_data!r})'

--- a/eval_anything/utils/serializers.py
+++ b/eval_anything/utils/serializers.py
@@ -1,0 +1,355 @@
+"""
+Serializers for different engines and modalities.
+
+TODO:
+- Add serializers for other backends
+- Add serializers for other modalities
+"""
+
+from functools import wraps
+from typing import Dict, Type, Optional, List
+from dataclasses import dataclass
+from abc import ABC, abstractmethod
+from enum import Enum, auto
+from vllm.sequence import Logprob
+from vllm.outputs import RequestOutput, RequestMetrics, CompletionOutput, LoRARequest
+from eval_anything.utils.data_type import InferenceOutput, MultiModalData, ModalityType
+
+
+class ModalitySerializerRegistry:
+    """Registry for modality-specific serializers"""
+    _registry: Dict[str, 'BaseModalitySerializer'] = {}
+    
+    @classmethod
+    def register(cls, modality: str):
+        def decorator(serializer_cls):
+            cls._registry[modality] = serializer_cls()
+            return serializer_cls
+        return decorator
+    
+    @classmethod
+    def get(cls, modality: str) -> Optional['BaseModalitySerializer']:
+        return cls._registry.get(modality, cls._registry.get('text'))
+
+class BaseModalitySerializer(ABC):
+    """Base class for modality-specific serializers"""
+    @abstractmethod
+    def serialize_input(self, mm_data: 'MultiModalData') -> dict:
+        """Serialize modality-specific input data"""
+        pass
+        
+    @abstractmethod
+    def serialize_output(self, mm_data: 'MultiModalData') -> dict:
+        """Serialize modality-specific output data"""
+        pass
+        
+    @abstractmethod
+    def deserialize_input(self, data: dict) -> 'MultiModalData':
+        """Deserialize modality-specific input data"""
+        pass
+        
+    @abstractmethod
+    def deserialize_output(self, data: dict) -> 'MultiModalData':
+        """Deserialize modality-specific output data"""
+        pass
+
+@ModalitySerializerRegistry.register('text')
+class TextModalitySerializer(BaseModalitySerializer):
+    def serialize_input(self, mm_data: 'MultiModalData') -> dict:
+        return {
+            'text': mm_data.text,
+            'type': 'text'
+        }
+    
+    def serialize_output(self, mm_data: 'MultiModalData') -> dict:
+        return {
+            'text': mm_data.text,
+            'type': 'text'
+        }
+    
+    def deserialize_input(self, data: dict) -> 'MultiModalData':
+        return MultiModalData(url=None, file=data['text'], modality=ModalityType.TEXT) 
+
+    def deserialize_output(self, data: dict) -> 'MultiModalData':
+        return MultiModalData(url=None, file=data['text'], modality=ModalityType.TEXT) 
+
+@ModalitySerializerRegistry.register('image')
+class ImageModalitySerializer(BaseModalitySerializer):
+    def serialize_input(self, mm_data: 'MultiModalData') -> dict:
+        return {
+            'url': mm_data.url,
+            'type': 'image'
+        }
+    
+    def serialize_output(self, mm_data: 'MultiModalData') -> dict:
+        return {
+            'url': mm_data.url,
+            'type': 'image'
+        }
+    
+    def deserialize_input(self, data: dict) -> 'MultiModalData':
+        return MultiModalData(url=data['url'], file=None, modality=ModalityType.IMAGE) # TODO: Replace with actual file
+        
+    def deserialize_output(self, data: dict) -> 'MultiModalData':
+        return MultiModalData(url=data['url'], file=None, modality=ModalityType.IMAGE) # TODO: Replace with actual file
+
+class SerializerRegistry:
+    """Registry for serializers"""
+    _registry: Dict[str, 'BaseSerializer'] = {}
+    
+    @classmethod
+    def register(cls, engine: str):
+        """Decorator to register a serializer for a specific engine"""
+        def decorator(serializer_cls):
+            cls._registry[engine] = serializer_cls()
+            return serializer_cls
+        return decorator
+    
+    @classmethod
+    def get(cls, engine: str) -> Optional['BaseSerializer']:
+        """Get serializer for specified engine"""
+        return cls._registry.get(engine, cls._registry.get('default'))
+
+class BaseSerializer(ABC):
+    """Base class for all serializers"""
+   
+    def serialize(self, output: 'InferenceOutput') -> dict:
+        """Serialize InferenceOutput to a dictionary"""
+        data = {
+            'engine': output.engine,
+            'task': output.task,
+            'uuid': output.uuid,
+            'response': output.response,
+        }
+        
+        if hasattr(output, 'response_token_ids'):
+            data['response_token_ids'] = output.response_token_ids
+
+        # Add additional fields based on engine-specific data
+        data.update(self._serialize_additional_fields(output))
+        
+        # TODO:modality specific data
+        # An example implementation of modality specific data serialization
+        if hasattr(output, 'mm_input_data') and output.mm_input_data:
+            data['mm_input_data'] = []
+            for mm_data in output.mm_input_data:
+                modality = mm_data.get_modality()
+                serializer = ModalitySerializerRegistry.get(modality)
+                data['mm_input_data'].append(serializer.serialize(mm_data))
+        if hasattr(output, 'mm_output_data') and output.mm_output_data:
+            data['mm_output_data'] = []
+            for mm_data in output.mm_output_data:
+                modality = mm_data.get_modality()
+                serializer = ModalitySerializerRegistry.get(modality)
+                data['mm_output_data'].append(serializer.serialize(mm_data))
+
+        return data
+
+    def deserialize(self, data: dict) -> 'InferenceOutput':
+        """Base deserialize method with common logic"""
+        engine = self.get_engine_type()
+
+        output = InferenceOutput(
+            engine=engine,
+            task=data['task'],
+            uuid=data['uuid'],
+            response=data['response'],
+        )
+
+        if 'response_token_ids' in data:
+            setattr(output, 'response_token_ids', data['response_token_ids'])
+
+        # TODO: modality specific data
+        # An example implementation of modality specific data deserialization
+        if 'mm_input_data' in data:
+            output.mm_input_data = []
+            for mm_data in data['mm_input_data']:
+                modality = mm_data['modality']
+                serializer = ModalitySerializerRegistry.get(modality)
+                setattr(output, 'mm_input_data', serializer.deserialize(mm_data))
+        if 'mm_output_data' in data:
+            output.mm_output_data = []
+            for mm_data in data['mm_output_data']:
+                modality = mm_data['modality']
+                serializer = ModalitySerializerRegistry.get(modality)
+                setattr(output, 'mm_output_data', serializer.deserialize(mm_data))
+
+        # Add additional fields based on engine-specific data
+        output = self._deserialize_additional_fields(data, output)
+        return output
+
+    def get_engine_type(self) -> str:
+        """Get the engine type for this serializer"""
+        return self.__class__.__name__.replace('Serializer', '').lower()
+
+    def _deserialize_additional_fields(self, data: dict, output: 'InferenceOutput'):
+        """Hook for engine-specific deserialization logic"""
+        return output
+
+    def _serialize_additional_fields(self, output: 'InferenceOutput') -> dict:
+        """Hook for engine-specific serialization logic"""
+        return {}
+
+@SerializerRegistry.register('vllm')
+class VLLMSerializer(BaseSerializer):
+    """Serializer for VLLM"""
+    def _serialize_additional_fields(self, output: 'InferenceOutput') -> dict:
+        """Hook for engine-specific serialization logic"""
+        return {
+            'response_logprobs': self._serialize_logprobs(output.response_logprobs),
+            'raw_output': self._serialize_raw_output(output.raw_output)
+        }
+
+    def _deserialize_additional_fields(self, data: dict, output: 'InferenceOutput'):
+        """Hook for engine-specific deserialization logic"""
+        if 'response_logprobs' in data:
+            setattr(output, 'response_logprobs', self._deserialize_logprobs(data['response_logprobs']))
+        if 'raw_output' in data:
+            setattr(output, 'raw_output', self._deserialize_raw_output(data['raw_output']))
+        return output
+
+    def _serialize_logprobs(self, logprobs):
+        """Serialize logprobs"""
+        if logprobs is None:
+            return None
+        return [
+            None if logprob_dict is None else {
+                str(token_id): {
+                    'logprob': info.logprob,
+                    'rank': info.rank,
+                    'decoded_token': info.decoded_token
+                } for token_id, info in logprob_dict.items()
+            }
+            for logprob_dict in logprobs
+        ]
+
+    def _serialize_raw_output(self, raw_output):
+        """Serialize raw output"""
+        if raw_output is None:
+            return None
+        return {
+            'request_id': raw_output.request_id,
+            'prompt': raw_output.prompt,
+            'prompt_token_ids': raw_output.prompt_token_ids,
+            'prompt_logprobs': self._serialize_logprobs(raw_output.prompt_logprobs),
+            'outputs': [
+                {
+                    'index': output.index,
+                    'text': output.text,
+                    'token_ids': output.token_ids,
+                    'cumulative_logprob': output.cumulative_logprob,
+                    'logprobs': output.logprobs,
+                    'finish_reason': output.finish_reason,
+                    'stop_reason': output.stop_reason,
+                    'lora_request': self._serialize_lora_request(output.lora_request) if output.lora_request else None
+                }
+                for output in raw_output.outputs
+            ],
+            'finished': raw_output.finished,
+            'metrics': self._serialize_metrics(raw_output.metrics) if raw_output.metrics else None,
+            'lora_request': self._serialize_lora_request(raw_output.lora_request) if raw_output.lora_request else None
+        }
+
+    def _deserialize_logprobs(self, data: dict) -> List[Optional[Dict[str, Dict[str, Dict[str, float]]]]]:
+        """Deserialize logprobs"""
+        return [
+            None if logprob_dict is None else {
+                str(token_id): {
+                    'logprob': info.logprob,
+                    'rank': info.rank,
+                    'decoded_token': info.decoded_token
+                } for token_id, info in logprob_dict.items()
+            }
+            for logprob_dict in data
+        ]
+    
+
+    def _deserialize_raw_output(self, data: dict) -> 'RequestOutput':
+        """Deserialize raw output"""
+        if data is None:
+            return None
+        return RequestOutput(
+            request_id=data['request_id'],
+            prompt=data['prompt'],
+            prompt_token_ids=data['prompt_token_ids'],
+            prompt_logprobs=self._deserialize_logprobs(data['prompt_logprobs']),
+            outputs=self._deserialize_outputs(data['outputs']),
+            finished=data['finished'],
+            metrics=self._deserialize_metrics(data['metrics']) if data['metrics'] else None,
+            lora_request=self._deserialize_lora_request(data['lora_request']) if data['lora_request'] else None
+        )
+    
+    def _deserialize_outputs(self, data: dict) -> List['CompletionOutput']:
+        return [
+            CompletionOutput(
+                index=output['index'],
+                text=output['text'],
+                token_ids=output['token_ids'],
+                cumulative_logprob=output['cumulative_logprob'],
+                logprobs=output['logprobs'],
+                finish_reason=output['finish_reason'],
+                stop_reason=output['stop_reason'],
+                lora_request=output['lora_request'],
+            )
+            for output in data['outputs']
+        ]
+
+    def _deserialize_metrics(self, metrics_data: List[dict]) -> List['RequestMetrics']:
+        """Deserialize metrics"""
+        if not metrics_data:
+            return None
+        return [
+            RequestMetrics(
+                arrival_time=metric['arrival_time'],
+                last_token_time=metric['last_token_time'],
+                first_scheduled_time=metric['first_scheduled_time'],
+                first_token_time=metric['first_token_time'],
+                time_in_queue=metric['time_in_queue'],
+                finished_time=metric['finished_time']
+            )
+            for metric in metrics_data
+        ]
+
+    def _deserialize_lora_request(self, data: dict) -> 'LoRARequest':
+        """Deserialize LoRARequest"""
+        if not data:
+            return None
+        return LoRARequest(
+            lora_name=data['lora_name'],
+            lora_int_id=data['lora_int_id'],
+            lora_path=data['lora_path'],
+            lora_local_path=data['lora_local_path'] if hasattr(data, 'lora_local_path') else None,
+            long_lora_max_len=data['long_lora_max_len'] if hasattr(data, 'long_lora_max_len') else None
+        )
+
+    def _serialize_metrics(self, metrics: List['RequestMetrics']) -> List[dict]:
+        """Serialize metrics"""
+        if not metrics:
+            return None
+        return [
+            {
+                'arrival_time': metric.arrival_time,
+                'last_token_time': metric.last_token_time,
+                'first_scheduled_time': metric.first_scheduled_time if hasattr(metric, 'first_scheduled_time') else None,
+                'first_token_time': metric.first_token_time if hasattr(metric, 'first_token_time') else None,
+                'time_in_queue': metric.time_in_queue if hasattr(metric, 'time_in_queue') else None,
+                'finished_time': metric.finished_time if hasattr(metric, 'finished_time') else None
+            }
+            for metric in metrics
+        ]
+
+    def _serialize_lora_request(self, lora_request: 'LoRARequest') -> dict:
+        """Serialize LoRARequest"""
+        if not lora_request:
+            return None
+        return {
+            'lora_name': lora_request.lora_name,
+            'lora_int_id': lora_request.lora_int_id,
+            'lora_path': lora_request.lora_path,
+            'lora_local_path': lora_request.lora_local_path if hasattr(lora_request, 'lora_local_path') else None,
+            'long_lora_max_len': lora_request.long_lora_max_len if hasattr(lora_request, 'long_lora_max_len') else None
+        }
+
+# TODO: Add serializers for other backends
+
+


### PR DESCRIPTION
支持了t2t的cache机制，同时预留了多模态接口。
**TODO**：
- [ ] 需适配InferenceInput, InferenceOutput的数据格式以扩写现有的cache代码
- [ ] 当前实现假定model_cfgs中有key ‘task_type'，根据不同任务种类选择cache file format
- [ ] 需要讨论一下cache的颗粒度。当前实现将InferenceOutput中的所有fields都做了serialization后存储。是否可以不必cache全部？