### PR TITLE
Add MMLU & HumanEval benchmarks

### DIFF
--- a/eval_anything/benchmarks/__init__.py
+++ b/eval_anything/benchmarks/__init__.py
@@ -3,6 +3,7 @@ import importlib
 benchmark_modules = [
     "benchmarks.text_to_text.gsm8k.eval",
     "benchmarks.text_to_text.mmlu.eval",
+    "benchmarks.text_to_text.HumanEval.eval",
 ]
 
 for module in benchmark_modules:

--- a/eval_anything/benchmarks/__init__.py
+++ b/eval_anything/benchmarks/__init__.py
@@ -2,6 +2,7 @@ import importlib
 
 benchmark_modules = [
     "benchmarks.text_to_text.gsm8k.eval",
+    "benchmarks.text_to_text.mmlu.eval",
 ]
 
 for module in benchmark_modules:

--- a/eval_anything/benchmarks/text_to_text/HumanEval/configs.yaml
+++ b/eval_anything/benchmarks/text_to_text/HumanEval/configs.yaml
@@ -1,0 +1,54 @@
+# ============================================
+# 评测配置：
+#   - 数据集hf路径
+#   - 数据集split
+#   - 数据集size
+#   - 数据集模态
+#   - 评测方式（multiple choice / generation / ...）
+#   - 评测指标（accuracy / ...）
+#   - 是否支持few_shot
+#   - 选项编号形式（ABCD或1234...），判断对错时的标识(true/false或者1/0...)
+# ============================================
+dataset:
+  name: HumanEval
+  path: openai/openai_humaneval
+  split: test
+  size: null
+  modality: text-to-text
+  fewshot_data_path: openai/openai_humaneval
+  fewshot_data_file: null
+  fewshot_data_split: null
+  cot_fewshot_data_path: benchmarks/cot_fewshot
+  cot_fewshot_data_file: null
+  cot_fewshot_data_split: null
+  max_shot: 5
+  default_task_list: ["openai_humaneval"]
+
+task:
+  - name: openai_humaneval
+    data_files: null
+    type: CodeGeneration
+    question_key: prompt
+    ground_truth_key: canonical_solution
+    has_metadata:  True
+    candidate_labels: null
+    avalable_evaluate_tools: ["extract_first_code_block", "extract_last_code_block"]
+answer_extractor:
+  - name: extract_first_code_block
+    function: regex_match_code
+    args:
+      match_index: 0
+  - name: extract_last_code_block
+    function: regex_match_code
+    args:
+      match_index: -1
+metrics:
+  - name: pass_rate
+    function: pass_rate
+    args:
+      null
+overall_metrics:
+  - name: null
+    function: null
+    args:
+      null

--- a/eval_anything/benchmarks/text_to_text/HumanEval/configs.yaml
+++ b/eval_anything/benchmarks/text_to_text/HumanEval/configs.yaml
@@ -17,7 +17,7 @@ dataset:
   modality: text-to-text
   fewshot_data_path: openai/openai_humaneval
   fewshot_data_file: null
-  fewshot_data_split: null
+  fewshot_data_split: test
   cot_fewshot_data_path: benchmarks/cot_fewshot
   cot_fewshot_data_file: null
   cot_fewshot_data_split: null
@@ -33,6 +33,7 @@ task:
     has_metadata:  True
     candidate_labels: null
     avalable_evaluate_tools: ["extract_first_code_block", "extract_last_code_block"]
+    language: python
 answer_extractor:
   - name: extract_first_code_block
     function: regex_match_code
@@ -46,7 +47,7 @@ metrics:
   - name: pass_rate
     function: pass_rate
     args:
-      null
+      k: 1
 overall_metrics:
   - name: null
     function: null

--- a/eval_anything/benchmarks/text_to_text/HumanEval/eval.py
+++ b/eval_anything/benchmarks/text_to_text/HumanEval/eval.py
@@ -1,0 +1,61 @@
+"""
+继承自eval-anything.pipeline.t2t_task
+"""
+from eval_anything.pipeline.t2t_benchmark import T2TBenchmark
+from collections import namedtuple
+from eval_anything.utils.data_type import EvaluationResult
+from eval_anything.models.base_model import BaseModel
+from eval_anything.utils.logger import EvalLogger
+from eval_anything.utils.register import BenchmarkRegistry
+from eval_anything.utils.cache_manager import CacheManager
+
+@BenchmarkRegistry.register('HumanEval')
+class HumanEvalBenchmark(T2TBenchmark):
+    def __init__(self, 
+                 model: BaseModel, 
+                 eval_cfgs: namedtuple, 
+                 model_cfgs: namedtuple, 
+                 infer_cfgs: namedtuple, 
+                 output_path: str,
+                 cache_manager: CacheManager,
+                 logger: EvalLogger):
+        super().__init__(model, eval_cfgs, model_cfgs, infer_cfgs, output_path, cache_manager, logger)
+        self.benchmark_name = "HumanEval"
+        self.benchmark_cfgs = self.get_benchmark_cfgs(self.benchmark_name)
+
+    def run(self, 
+            task_list: list[str],) -> tuple[dict[str, list[EvaluationResult]], dict[str, dict[str, float]], dict[str, dict[str, float]]]:
+        """Run benchmark
+        Args:
+            task_list (list[str]): task list
+            
+        Returns:
+            evaluation_details (dict[str, list[EvaluationResult]]): evaluation details
+            evaluation_results (dict[str, dict[str, float]]): evaluation results
+        """
+        self.logger.log('info', f'Evaluating {self.benchmark_name}...')
+
+        dataloader = self.init_dataloader(self.eval_cfgs, self.benchmark_cfgs)
+        input_data = dataloader.load_dataset(task_list)    # Input_data: list[InferenceInput]
+        metadata = []
+        for key, value in input_data.items():
+            metadata = [item.metadata for item in value]
+        
+        inference_outputs = self.batch_inference(self.model, input_data)
+        
+        evaluation_details = {}
+        evaluation_results = {}
+
+        for task in task_list:
+            evaluation_details[task], evaluation_results[task] = self.calculate_metrics(self.benchmark_name, inference_outputs[task], metadata, self.benchmark_cfgs.answer_extractor, self.benchmark_cfgs.metrics)
+
+        if len(task_list) > 1:
+            overall_result = self.calculate_overall_metrics(self.benchmark_cfgs.overall_metrics, result=evaluation_results)
+        else:
+            overall_result = {}
+            
+        self.display_benchmark_results(self.benchmark_name, evaluation_results)
+        if overall_result != {}:
+            self.display_benchmark_results(self.benchmark_name, overall_result)
+        self.save_benchmark_details(self.output_path, self.benchmark_name, input_data, evaluation_details)
+        return evaluation_details, evaluation_results, overall_result

--- a/eval_anything/benchmarks/text_to_text/mmlu/configs.yaml
+++ b/eval_anything/benchmarks/text_to_text/mmlu/configs.yaml
@@ -1,0 +1,234 @@
+# ============================================
+# 评测配置：
+#   - 数据集hf路径
+#   - 数据集split
+#   - 数据集size
+#   - 数据集模态
+#   - 评测方式（multiple choice / generation / ...）
+#   - 评测指标（accuracy / ...）
+#   - 是否支持few_shot
+#   - 选项编号形式（ABCD或1234...），判断对错时的标识(true/false或者1/0...)
+# ============================================
+dataset:
+  name: mmlu
+  path: cais/mmlu
+  split: test
+  size: null  # Dynamic based on subject
+  modality: text-to-text
+  fewshot_data_path: cais/mmlu
+  fewshot_data_file: ["abstract_algebra/dev*.parquet"]
+  fewshot_data_split: train
+  cot_fewshot_data_path: benchmarks/cot_fewshot
+  cot_fewshot_data_file: null
+  cot_fewshot_data_split: null
+  max_shot: 5
+  default_task_list: ["all"]
+
+# Default task configuration that applies to all tasks
+task_defaults: &task_defaults
+  type: MultiChoice
+  question_key: question
+  answer_key: choices
+  ground_truth_key: answer
+  candidate_labels: ["A", "B", "C", "D"]
+  avalable_evaluate_tools: ["match_letter_after_pattern", "match_letter_in_parentheses"]
+
+task:
+  - name: all
+    data_files: ["all/test*.parquet"]
+    <<: *task_defaults
+  - name: abstract_algebra
+    data_files: ["abstract_algebra/test*.parquet"]
+    <<: *task_defaults
+  - name: anatomy
+    data_files: ["anatomy/test*.parquet"]
+    <<: *task_defaults
+  - name: astronomy
+    data_files: ["astronomy/test*.parquet"]
+    <<: *task_defaults
+  - name: business_ethics
+    data_files: ["business_ethics/test*.parquet"]
+    <<: *task_defaults
+  - name: clinical_knowledge
+    data_files: ["clinical_knowledge/test*.parquet"]
+    <<: *task_defaults
+  - name: college_biology
+    data_files: ["college_biology/test*.parquet"]
+    <<: *task_defaults
+  - name: college_chemistry
+    data_files: ["college_chemistry/test*.parquet"]
+    <<: *task_defaults
+  - name: college_computer_science
+    data_files: ["college_computer_science/test*.parquet"]
+    <<: *task_defaults
+  - name: college_mathematics
+    data_files: ["college_mathematics/test*.parquet"]
+    <<: *task_defaults
+  - name: college_medicine
+    data_files: ["college_medicine/test*.parquet"]
+    <<: *task_defaults
+  - name: college_physics
+    data_files: ["college_physics/test*.parquet"]
+    <<: *task_defaults
+  - name: computer_security
+    data_files: ["computer_security/test*.parquet"]
+    <<: *task_defaults
+  - name: conceptual_physics
+    data_files: ["conceptual_physics/test*.parquet"]
+    <<: *task_defaults
+  - name: econometrics
+    data_files: ["econometrics/test*.parquet"]
+    <<: *task_defaults
+  - name: electrical_engineering
+    data_files: ["electrical_engineering/test*.parquet"]
+    <<: *task_defaults
+  - name: elementary_mathematics
+    data_files: ["elementary_mathematics/test*.parquet"]
+    <<: *task_defaults
+  - name: formal_logic
+    data_files: ["formal_logic/test*.parquet"]
+    <<: *task_defaults
+  - name: global_facts
+    data_files: ["global_facts/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_biology
+    data_files: ["high_school_biology/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_chemistry
+    data_files: ["high_school_chemistry/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_computer_science
+    data_files: ["high_school_computer_science/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_european_history
+    data_files: ["high_school_european_history/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_geography
+    data_files: ["high_school_geography/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_government_and_politics
+    data_files: ["high_school_government_and_politics/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_macroeconomics
+    data_files: ["high_school_macroeconomics/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_mathematics
+    data_files: ["high_school_mathematics/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_microeconomics
+    data_files: ["high_school_microeconomics/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_physics
+    data_files: ["high_school_physics/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_psychology
+    data_files: ["high_school_psychology/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_statistics
+    data_files: ["high_school_statistics/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_us_history
+    data_files: ["high_school_us_history/test*.parquet"]
+    <<: *task_defaults
+  - name: high_school_world_history
+    data_files: ["high_school_world_history/test*.parquet"]
+    <<: *task_defaults
+  - name: human_aging
+    data_files: ["human_aging/test*.parquet"]
+    <<: *task_defaults
+  - name: human_sexuality
+    data_files: ["human_sexuality/test*.parquet"]
+    <<: *task_defaults
+  - name: international_law
+    data_files: ["international_law/test*.parquet"]
+    <<: *task_defaults
+  - name: jurisprudence
+    data_files: ["jurisprudence/test*.parquet"]
+    <<: *task_defaults
+  - name: logical_fallacies
+    data_files: ["logical_fallacies/test*.parquet"]
+    <<: *task_defaults
+  - name: machine_learning
+    data_files: ["machine_learning/test*.parquet"]
+    <<: *task_defaults
+  - name: management
+    data_files: ["management/test*.parquet"]
+    <<: *task_defaults
+  - name: marketing
+    data_files: ["marketing/test*.parquet"]
+    <<: *task_defaults
+  - name: medical_genetics
+    data_files: ["medical_genetics/test*.parquet"]
+    <<: *task_defaults
+  - name: miscellaneous
+    data_files: ["miscellaneous/test*.parquet"]
+    <<: *task_defaults
+  - name: moral_disputes
+    data_files: ["moral_disputes/test*.parquet"]
+    <<: *task_defaults
+  - name: moral_scenarios
+    data_files: ["moral_scenarios/test*.parquet"]
+    <<: *task_defaults
+  - name: nutrition
+    data_files: ["nutrition/test*.parquet"]
+    <<: *task_defaults
+  - name: philosophy
+    data_files: ["philosophy/test*.parquet"]
+    <<: *task_defaults
+  - name: prehistory
+    data_files: ["prehistory/test*.parquet"]
+    <<: *task_defaults
+  - name: professional_accounting
+    data_files: ["professional_accounting/test*.parquet"]
+    <<: *task_defaults
+  - name: professional_law
+    data_files: ["professional_law/test*.parquet"]
+    <<: *task_defaults
+  - name: professional_medicine
+    data_files: ["professional_medicine/test*.parquet"]
+    <<: *task_defaults
+  - name: professional_psychology
+    data_files: ["professional_psychology/test*.parquet"]
+    <<: *task_defaults
+  - name: public_relations
+    data_files: ["public_relations/test*.parquet"]
+    <<: *task_defaults
+  - name: security_studies
+    data_files: ["security_studies/test*.parquet"]
+    <<: *task_defaults
+  - name: sociology
+    data_files: ["sociology/test*.parquet"]
+    <<: *task_defaults
+  - name: us_foreign_policy
+    data_files: ["us_foreign_policy/test*.parquet"]
+    <<: *task_defaults
+  - name: virology
+    data_files: ["virology/test*.parquet"]
+    <<: *task_defaults
+  - name: world_religions
+    data_files: ["world_religions/test*.parquet"]
+    <<: *task_defaults
+
+answer_extractor:
+  - name: match_last_letter
+    function: regex_match_letter
+    args:
+      additional_pattern: "{original_pattern}"
+      match_index: -1
+  - name: match_first_letter
+    function: regex_match_letter
+    args:
+      additional_pattern: "{original_pattern}"
+      match_index: 0
+
+metrics:
+  - name: accuracy
+    function: accuracy
+    args:
+
+overall_metrics:
+  - name: null
+    function: null
+    args:
+      null
+  

--- a/eval_anything/benchmarks/text_to_text/mmlu/eval.py
+++ b/eval_anything/benchmarks/text_to_text/mmlu/eval.py
@@ -1,0 +1,62 @@
+"""
+继承自eval-anything.pipeline.t2t_task
+"""
+from eval_anything.pipeline.t2t_benchmark import T2TBenchmark
+from collections import namedtuple
+from eval_anything.utils.data_type import EvaluationResult
+from eval_anything.evaluate_tools.t2t_tools import RegexMatchLetter
+from eval_anything.models.base_model import BaseModel
+from eval_anything.utils.logger import EvalLogger
+from eval_anything.utils.register import BenchmarkRegistry
+from eval_anything.utils.cache_manager import CacheManager
+
+@BenchmarkRegistry.register('mmlu')
+class MMLUBenchmark(T2TBenchmark):
+    def __init__(self, 
+                 model: BaseModel, 
+                 eval_cfgs: namedtuple, 
+                 model_cfgs: namedtuple, 
+                 infer_cfgs: namedtuple, 
+                 output_path: str,
+                 cache_manager: CacheManager,
+                 logger: EvalLogger):
+        super().__init__(model, eval_cfgs, model_cfgs, infer_cfgs, output_path, cache_manager, logger)
+        self.benchmark_name = "mmlu"
+        self.benchmark_cfgs = self.get_benchmark_cfgs(self.benchmark_name)
+
+    def run(self, 
+            task_list: list[str],) -> tuple[dict[str, list[EvaluationResult]], dict[str, dict[str, float]], dict[str, dict[str, float]]]:
+        """Run benchmark
+        Args:
+            task_list (list[str]): task list
+            
+        Returns:
+            evaluation_details (dict[str, list[EvaluationResult]]): evaluation details
+            evaluation_results (dict[str, dict[str, float]]): evaluation results
+        """
+        self.logger.log('info', f'Evaluating {self.benchmark_name}...')
+
+        dataloader = self.init_dataloader(self.eval_cfgs, self.benchmark_cfgs)
+        input_data = dataloader.load_dataset(task_list)    # Input_data: list[InferenceInput]
+        
+        inference_outputs = self.batch_inference(self.model, input_data)
+        ref_answers = {task: self.get_ref_answer(input_data[task], inference_outputs[task]) for task in task_list}
+        evaluation_details = {}
+        evaluation_results = {}
+
+        for task in task_list:
+            # Map int 0,1,2,3 to A,B,C,D
+            ground_truth = [chr(65 + answer) for answer in ref_answers[task]]
+            evaluation_details[task], evaluation_results[task] = self.calculate_metrics(self.benchmark_name, inference_outputs[task], ground_truth, self.benchmark_cfgs.answer_extractor, self.benchmark_cfgs.metrics)
+
+        if len(task_list) > 1:
+            overall_result = self.calculate_overall_metrics(self.benchmark_cfgs.overall_metrics, result=evaluation_results)
+        else:
+            overall_result = {}
+            
+        self.display_benchmark_results(self.benchmark_name, evaluation_results)
+        if overall_result != {}:
+            self.display_benchmark_results(self.benchmark_name, overall_result)
+        self.save_benchmark_details(self.output_path, self.benchmark_name, input_data, evaluation_details)
+        return evaluation_details, evaluation_results, overall_result
+    

--- a/eval_anything/configs/evaluate.yaml
+++ b/eval_anything/configs/evaluate.yaml
@@ -8,15 +8,18 @@
     task_uid: 111
     # benchmark name and task name, if the task list is empty, all tasks will be evaluated
     benchmarks: {
-      "gsm8k": ["main"]
+      #"gsm8k": ["main"],
+      "mmlu": ["abstract_algebra"]
       }
     # Num shot
     n_shot: {
-      "gsm8k": 5
+      #"gsm8k": 5,
+      "mmlu": 5
       }
     # Chain of thought
     cot: {
-      "gsm8k": True
+      #"gsm8k": True,
+      "mmlu": False
       }
   # The model configurations
   model_cfgs:

--- a/eval_anything/configs/evaluate.yaml
+++ b/eval_anything/configs/evaluate.yaml
@@ -9,19 +9,19 @@
     # benchmark name and task name, if the task list is empty, all tasks will be evaluated
     benchmarks: {
       #"gsm8k": ["main"],
-      #"mmlu": ["abstract_algebra"]
+      "mmlu": ["global_facts"],
       "HumanEval": ["openai_humaneval"]
       }
     # Num shot
     n_shot: {
       #"gsm8k": 5,
-      #"mmlu": 0
+      "mmlu": 0,
       "HumanEval": 0
       }
     # Chain of thought
     cot: {
       #"gsm8k": True,
-      #"mmlu": False
+      "mmlu": True,
       "HumanEval": False
       }
   # The model configurations
@@ -60,9 +60,9 @@
     # Beam Search size
     num_beams: null
     # Number of GPUs
-    num_gpu: 2
+    num_gpu: 8
     # Available GPU IDs. If not specified, first num_gpu GPUs will be used.
-    gpu_ids: [2,3]
+    gpu_ids: [0,1,2,3,4,5,6,7]
     # GPU utilization
     gpu_utilization: 0.8
     

--- a/eval_anything/configs/evaluate.yaml
+++ b/eval_anything/configs/evaluate.yaml
@@ -9,17 +9,20 @@
     # benchmark name and task name, if the task list is empty, all tasks will be evaluated
     benchmarks: {
       #"gsm8k": ["main"],
-      "mmlu": ["abstract_algebra"]
+      #"mmlu": ["abstract_algebra"]
+      "HumanEval": ["openai_humaneval"]
       }
     # Num shot
     n_shot: {
       #"gsm8k": 5,
-      "mmlu": 5
+      #"mmlu": 0
+      "HumanEval": 0
       }
     # Chain of thought
     cot: {
       #"gsm8k": True,
-      "mmlu": False
+      #"mmlu": False
+      "HumanEval": False
       }
   # The model configurations
   model_cfgs:
@@ -47,7 +50,7 @@
     # Top-P
     top_p: 0.95
     # Temperature
-    temperature: 0.5
+    temperature: 0.1
     # Prompt Logprobs
     prompt_logprobs: 0
     # Logprobs
@@ -59,7 +62,7 @@
     # Number of GPUs
     num_gpu: 2
     # Available GPU IDs. If not specified, first num_gpu GPUs will be used.
-    gpu_ids: [6,7]
+    gpu_ids: [2,3]
     # GPU utilization
     gpu_utilization: 0.8
     

--- a/eval_anything/dataloader/base_dataloader.py
+++ b/eval_anything/dataloader/base_dataloader.py
@@ -26,6 +26,7 @@ class BaseDataLoader:
     task_type_map = {
         'Dialogue': 'build_dialogue_prompt',
         'MultiChoice': 'build_multi_choice_prompt',
+        'CodeGeneration': 'build_codes_generation_prompt'
     }
 
     def __init__(self, eval_cfgs, bench_cfgs, logger):
@@ -59,8 +60,16 @@ class BaseDataLoader:
             else:
                 dataset = load_dataset(self.data_dir, task.name, split=self.bench_cfgs.dataset.split)
             self.few_shot_data = self.set_fewshot_dataset(task.name) if self.num_shot != 0 else None
+
+            # Build prompts
             prompt_builder = getattr(self, self.task_type_map[task.type])
             prompts[task.name] = prompt_builder(task, dataset)
+
+            # Save metadata if needed
+            if task.has_metadata:
+                for i, item in enumerate(prompts[task.name]):
+                    item.metadata = dataset[i]
+
         return prompts
 
     def set_fewshot_dataset(self, task: str):

--- a/eval_anything/dataloader/t2t_dataloader.py
+++ b/eval_anything/dataloader/t2t_dataloader.py
@@ -62,7 +62,8 @@ class T2TDataLoader(BaseDataLoader):
         few_shot_examples = self.few_shot_data[: self.num_shot] if self.num_shot else []
         prompt_builder = CodesGenerationPromptBuilder(
             few_shot_examples=few_shot_examples,
-            cot=self.enable_cot
+            cot=self.enable_cot,
+            language=task.language
         )
         prompts = []
         question_key = task.question_key

--- a/eval_anything/dataloader/t2t_dataloader.py
+++ b/eval_anything/dataloader/t2t_dataloader.py
@@ -22,7 +22,7 @@ from eval_anything.dataloader.base_dataloader import BaseDataLoader
 
 
 # from eval_anything.utils.registry import TemplateRegistry as get_template_class
-from eval_anything.utils.utils import MultiChoicePromptBuilder, DialoguePromptBuilder
+from eval_anything.utils.utils import MultiChoicePromptBuilder, DialoguePromptBuilder, CodesGenerationPromptBuilder
 from eval_anything.utils.data_type import InferenceInput
 
 
@@ -55,5 +55,20 @@ class T2TDataLoader(BaseDataLoader):
         question_key = task.question_key
         ground_truth_key = task.ground_truth_key
         prompts = [InferenceInput(task=task.name, text=prompt_builder.build_prompt(item[question_key]), ref_answer=item[ground_truth_key]) for item in data]
+        
+        return prompts
+    
+    def build_codes_generation_prompt(self, task: namedtuple, data: list[dict]):
+        few_shot_examples = self.few_shot_data[: self.num_shot] if self.num_shot else []
+        prompt_builder = CodesGenerationPromptBuilder(
+            few_shot_examples=few_shot_examples,
+            cot=self.enable_cot
+        )
+        prompts = []
+        question_key = task.question_key
+        ground_truth_key = task.ground_truth_key
+        for item in data:
+            prompt = prompt_builder.build_prompt(item[question_key], item[ground_truth_key])
+            prompts.append(InferenceInput(task=task.name, text=prompt, ref_answer=item[ground_truth_key]))
         
         return prompts

--- a/eval_anything/dataloader/t2t_dataloader.py
+++ b/eval_anything/dataloader/t2t_dataloader.py
@@ -28,7 +28,7 @@ from eval_anything.utils.data_type import InferenceInput
 
 class T2TDataLoader(BaseDataLoader):
     
-    def build_multi_choice_prompt(self, task: namedtuple, data: list[str]):
+    def build_multi_choice_prompt(self, task: namedtuple, data: list[dict]):
         few_shot_examples = self.few_shot_data[: self.num_shot] if self.num_shot else []
         # template = get_template_class(self.chat_template)
         prompt_builder = MultiChoicePromptBuilder(
@@ -46,10 +46,10 @@ class T2TDataLoader(BaseDataLoader):
         
         return prompts
 
-    def build_dialogue_prompt(self, task: namedtuple, data: list[str]):
+    def build_dialogue_prompt(self, task: namedtuple, data: list[dict]):
         few_shot_examples = self.few_shot_data[: self.num_shot] if self.num_shot else []
         prompt_builder = DialoguePromptBuilder(
-            few_shot_examples=few_shot_examples,
+            few_shot_examples=few_shot_examples, 
             cot=self.enable_cot
         )
         question_key = task.question_key

--- a/eval_anything/evaluate_tools/base_tools.py
+++ b/eval_anything/evaluate_tools/base_tools.py
@@ -1,11 +1,15 @@
 from abc import ABC, abstractmethod
-from typing import List
+from eval_anything.utils.logger import EvalLogger
+
+metric_logger = EvalLogger(name="MetricLogger")
+tool_logger = EvalLogger(name="ToolLogger")
 
 class BaseTool(ABC):
     def __init__(self, **kwargs) -> None:
         for key, value in kwargs.items():
             setattr(self, key, value)
-    
+        self.logger = tool_logger
+        
     @abstractmethod
     def apply(self, **kwargs):
         pass
@@ -17,6 +21,7 @@ class BaseMetric(ABC):
     def __init__(self, **kwargs) -> None:
         for key, value in kwargs.items():
             setattr(self, key, value)
+        self.logger = metric_logger
             
     @abstractmethod
     def calculate(self):

--- a/eval_anything/evaluate_tools/metrics.py
+++ b/eval_anything/evaluate_tools/metrics.py
@@ -1,14 +1,22 @@
 from abc import ABC, abstractmethod
 from typing import List, Iterable, Union, Dict
-from collections import namedtuple
+from collections import namedtuple, defaultdict, Counter
 from eval_anything.evaluate_tools.base_tools import BaseTool, BaseMetric
 from eval_anything.utils.register import MetricRegistry
 from eval_anything.utils.data_type import EvaluationResult
 import eval_anything.evaluate_tools.t2t_tools as T2T_TOOLS
 from eval_anything.evaluate_tools.t2t_tools import T2T_JUDGER_MAP
+from eval_anything.utils.utils import check_correctness, estimate_pass_at_k
+from eval_anything.utils.logger import EvalLogger
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from collections import Counter
+import tqdm
+import numpy as np
+import os
 
 class MetricCalculator(BaseTool):
     def __init__(self, metrics_list: List[namedtuple], judge_method: str):
+        self.logger
         self.metrics = []
         self.metrics_args = []
         self.judge_method = judge_method
@@ -176,3 +184,59 @@ class AverageAcrossTasks(BaseMetric):
     
     def __call__(self, overall_evaluation_results: Dict[str, Dict[str, float]], **kwargs: None) -> Dict[str, float]:
         return self.calculate(overall_evaluation_results, **kwargs)
+
+
+@MetricRegistry.register('pass_rate')
+class PassAtK(BaseMetric):
+    def calculate(self, evaluation_results: List[EvaluationResult], judge_method: str, k: int = 1, n_workers: int = 4, timeout: float = 3.0, **kwargs) -> dict[str, float]:
+        # Set tokenizer parallelism at the start
+        os.environ["TOKENIZERS_PARALLELISM"] = "false"
+        
+        # Initialize results for each extractor
+        pass_at_k = {extractor: {} for extractor in evaluation_results[0].extracted_result.keys()}
+        
+        # Process each extractor separately
+        for extractor in evaluation_results[0].extracted_result.keys():
+            results = defaultdict(list)
+            
+            # Process results in parallel with progress tracking
+            with ThreadPoolExecutor(max_workers=n_workers) as executor:
+                futures = []
+                completion_id = Counter()
+                n_samples = 0
+
+                print(f"Preparing Completions for {extractor}...")
+                for sample in tqdm.tqdm(evaluation_results):
+                    task_id = sample.ground_truth.get("task_id", "")
+                    completion = sample.extracted_result[extractor]
+                    args = (sample.ground_truth, completion, timeout, completion_id[task_id])
+                    future = executor.submit(check_correctness, *args)
+                    futures.append(future)
+                    completion_id[task_id] += 1
+                    n_samples += 1
+
+                assert len(completion_id) == len(evaluation_results), "Some problems are not attempted."
+
+                print(f"Running test suites for {extractor}...")
+                for future in tqdm.tqdm(as_completed(futures), total=len(futures)):
+                    result = future.result()
+                    results[result["task_id"]].append((result["completion_id"], result))
+
+            # Calculate pass@k for this extractor
+            total, correct = [], []
+            for result in results.values():
+                result.sort()
+                passed = [r[1]["passed"] for r in result]
+                total.append(len(passed))
+                correct.append(sum(passed))
+            total = np.array(total)
+            correct = np.array(correct)
+
+            # Calculate pass@k score if we have enough samples
+            if (total >= k).all():
+                pass_at_k[extractor] = estimate_pass_at_k(total, correct, k).mean()
+
+        return pass_at_k
+    
+    def __call__(self, evaluation_results: List[EvaluationResult], judge_method: str, **kwargs) -> dict[str, float]:
+        return self.calculate(evaluation_results, judge_method, **kwargs)

--- a/eval_anything/evaluate_tools/t2t_tools.py
+++ b/eval_anything/evaluate_tools/t2t_tools.py
@@ -7,7 +7,7 @@ from typing import Union, List, Iterable
 
 T2T_EXTRACTOR_MAP = {
     "regex_match_number": "RegexMatchNumber",
-    "regex_match_text": "RegexMatch",
+    "regex_match_letter": "RegexMatchLetter"
 }
 
 T2T_JUDGER_MAP = {
@@ -51,6 +51,25 @@ class RegexMatchNumber(RegexMatch):
         self.pattern = additional_pattern.format(original_pattern=pattern_match_number) if additional_pattern else pattern_match_number
         self.match_index = match_index
         
+class RegexMatchText(RegexMatch):
+    def __init__(self, additional_pattern: str = None, match_index: int = None):
+        # Pattern to match single letter answers A, B, C, D (case insensitive)
+        pattern_match_text = r"[A-Da-d]"
+        self.pattern = additional_pattern.format(original_pattern=pattern_match_text) if additional_pattern else pattern_match_text
+        self.match_index = match_index
+
+    def apply(self, data: Union[List, Iterable]) -> Union[List, None]:
+        """
+        Match letter answers in the text and convert to uppercase.
+        Args:
+            data (list/iterable): the text to be matched
+        Returns:
+            list/None: the matched result in uppercase
+        """
+        matches = super().apply(data)
+        # Convert matched letters to uppercase for consistency
+        return [match.upper() if match else None for match in matches]
+
 class JudgeEqual(BaseTool):
     def __init__(self):
         super().__init__()
@@ -60,3 +79,29 @@ class JudgeEqual(BaseTool):
     
     def __call__(self, data_1, data_2) -> bool:
         return self.apply(data_1, data_2)
+
+class RegexMatchLetter(RegexMatch):
+    def __init__(self, additional_pattern: str = None, match_index: int = None):
+        # Base pattern to match letters in parentheses (A-D)
+        pattern_match_letter = r"\(([A-Da-d])\)"  # Capture the letter between parentheses
+        self.pattern = additional_pattern.format(original_pattern=pattern_match_letter) if additional_pattern else pattern_match_letter
+        self.match_index = match_index
+
+    def apply(self, data: Union[List, Iterable]) -> Union[List, None]:
+        def match_text(text):
+            import re
+            pattern = re.compile(self.pattern, re.IGNORECASE)
+            match = list(pattern.finditer(text))
+            if match:
+                if self.match_index is not None:
+                    # Extract just the letter part (group 1) and convert to uppercase
+                    return match[self.match_index].group(1).upper()
+                else:
+                    return match.group(1).upper()
+            else:
+                return None
+        matches = [match_text(item) for item in data]
+        return matches
+
+
+

--- a/eval_anything/evaluate_tools/t2t_tools.py
+++ b/eval_anything/evaluate_tools/t2t_tools.py
@@ -105,31 +105,54 @@ class RegexMatchLetter(RegexMatch):
         return matches
 
 class RegexMatchCode(RegexMatch):
-    def __init__(self, additional_pattern: str = None, match_index: int = None):
+    def __init__(self, additional_pattern: str = None, match_index: int = None, language: str = "python"):
         # Pattern to match code blocks between ```python ``` or ``` ```
-        pattern_match_code = r"```(?:python)?\s*(.*?)\s*```"
+        pattern_match_code = r"```(?:{language})?\s*([\s\S]*?)\s*```"
         self.pattern = additional_pattern.format(original_pattern=pattern_match_code) if additional_pattern else pattern_match_code
         self.match_index = match_index
+        self.language = language
 
     def apply(self, data: Union[List, Iterable]) -> Union[List, None]:
         def match_text(text):
             import re
-            pattern = re.compile(self.pattern, re.DOTALL)  # Use DOTALL to match across newlines
-            matches = list(pattern.finditer(text))
-            if matches:
-                if self.match_index is not None:
-                    # Handle negative index (last match)
-                    if self.match_index < 0:
-                        self.match_index = len(matches) + self.match_index
-                    if 0 <= self.match_index < len(matches):
-                        return matches[self.match_index].group(1).strip()
-                    return None
-                else:
-                    return matches[0].group(1).strip()
-            return None
+            # Find all positions of ```language and ``` markers
+            language_pattern = r"```{}".format(self.language)
+            close_pattern = r"```"
+            language_positions = [m.start() for m in re.finditer(language_pattern, text)]
+            close_positions = [m.start() for m in re.finditer(close_pattern, text)]
+            
+            if not language_positions or not close_positions:
+                return ""
+            
+            # Match each ```language with its next ``` marker
+            code_blocks = []
+            for lang_start in language_positions:
+                # Find the next closing marker after this language marker
+                next_close = None
+                for close_pos in close_positions:
+                    if close_pos > lang_start:
+                        next_close = close_pos
+                        break
+                
+                if next_close is not None:
+                    block_content = text[lang_start:next_close + 3]  # Include the closing ```
+                    # Clean up the content
+                    content = re.sub(r'^```{}\s*'.format(self.language), '', block_content)
+                    content = re.sub(r'\s*```$', '', content)
+                    code_blocks.append(content)
+            
+            if not code_blocks:
+                return ""
+            
+            # Return the specific match based on index
+            if self.match_index is not None:
+                if self.match_index < 0:
+                    self.match_index = len(code_blocks) + self.match_index
+                if 0 <= self.match_index < len(code_blocks):
+                    return code_blocks[self.match_index]
+                return ""
+            else:
+                return code_blocks[0]  # Default to first match
             
         matches = [match_text(item) for item in data]
         return matches
-    
-
-

--- a/eval_anything/evaluate_tools/t2t_tools.py
+++ b/eval_anything/evaluate_tools/t2t_tools.py
@@ -7,7 +7,8 @@ from typing import Union, List, Iterable
 
 T2T_EXTRACTOR_MAP = {
     "regex_match_number": "RegexMatchNumber",
-    "regex_match_letter": "RegexMatchLetter"
+    "regex_match_letter": "RegexMatchLetter",
+    "regex_match_code": "RegexMatchCode"
 }
 
 T2T_JUDGER_MAP = {
@@ -103,5 +104,32 @@ class RegexMatchLetter(RegexMatch):
         matches = [match_text(item) for item in data]
         return matches
 
+class RegexMatchCode(RegexMatch):
+    def __init__(self, additional_pattern: str = None, match_index: int = None):
+        # Pattern to match code blocks between ```python ``` or ``` ```
+        pattern_match_code = r"```(?:python)?\s*(.*?)\s*```"
+        self.pattern = additional_pattern.format(original_pattern=pattern_match_code) if additional_pattern else pattern_match_code
+        self.match_index = match_index
+
+    def apply(self, data: Union[List, Iterable]) -> Union[List, None]:
+        def match_text(text):
+            import re
+            pattern = re.compile(self.pattern, re.DOTALL)  # Use DOTALL to match across newlines
+            matches = list(pattern.finditer(text))
+            if matches:
+                if self.match_index is not None:
+                    # Handle negative index (last match)
+                    if self.match_index < 0:
+                        self.match_index = len(matches) + self.match_index
+                    if 0 <= self.match_index < len(matches):
+                        return matches[self.match_index].group(1).strip()
+                    return None
+                else:
+                    return matches[0].group(1).strip()
+            return None
+            
+        matches = [match_text(item) for item in data]
+        return matches
+    
 
 

--- a/eval_anything/pipeline/base_benchmark.py
+++ b/eval_anything/pipeline/base_benchmark.py
@@ -164,7 +164,7 @@ class BaseBenchmark(ABC):
         """
         output_text = [item.response[0] for item in inference_outputs]
         extracted_results = {}
-        for answer_extractor in answer_extractors[2:]:
+        for answer_extractor in answer_extractors:
             extracted_results[answer_extractor.name] = getattr(T2T_TOOLS, T2T_EXTRACTOR_MAP[answer_extractor.function])(**(answer_extractor.args._asdict())).apply(output_text)
         
         evaluation_details = []

--- a/eval_anything/pipeline/base_benchmark.py
+++ b/eval_anything/pipeline/base_benchmark.py
@@ -90,6 +90,7 @@ class BaseBenchmark(ABC):
             if self.enable_cache:
                 cache_path, cache_exist = self.cache_manager.get_cache_path(
                     self.model_cfgs, 
+                    self.infer_cfgs,
                     input_data_batch
                 )
                 if cache_exist:

--- a/eval_anything/pipeline/t2t_benchmark.py
+++ b/eval_anything/pipeline/t2t_benchmark.py
@@ -49,6 +49,6 @@ class T2TBenchmark(BaseBenchmark):
                         "output": output.to_dict()
                     }
                 )
-            with open(os.path.join(output_dir, f"details_{task}.jsonl"), 'a') as f:
+            with open(os.path.join(output_dir, f"details_{task}.jsonl"), 'a', encoding='utf-8') as f:
                 for detail in save_details:
                     f.write(json.dumps(detail, ensure_ascii=False) + '\n')

--- a/eval_anything/utils/cache_manager.py
+++ b/eval_anything/utils/cache_manager.py
@@ -88,17 +88,22 @@ class CacheManager:
         self.cache_dir = cache_dir
         self.binary_cache = BinaryCache(cache_dir, logger)
         
-    def get_cache_path(self, model_cfg: namedtuple, inputs: List[InferenceInput]) -> Tuple[str, bool]:
-        """Get cache path and check if exists
-        
-        Args:
-            model_cfg: Model configuration dictionary
-            inputs: List of inference inputs
-            
-        Returns:
-            Tuple of (cache_key, exists_flag)
-        """
+    def get_cache_path(self, model_cfg: namedtuple, infer_cfgs: namedtuple, inputs: List[InferenceInput]) -> Tuple[str, bool]:
+        """Get cache path and check if exists"""
+        # Get base model name
         model_name = getattr(model_cfg, 'model_id', time.strftime("%Y%m%d_%H%M%S", time.localtime()))
+        
+        # Get all relevant inference parameters
+        infer_params = []
+        
+        for param in dir(infer_cfgs):
+            value = getattr(infer_cfgs, param)
+            if value is not None:
+                infer_params.append(f"{param}={value}")
+
+        # Append inference parameters to model name
+        if infer_params:
+            model_name = f"{model_name}_{'_'.join(infer_params)}"
         
         # Create deterministic string representation of inputs
         input_strings = []

--- a/eval_anything/utils/cache_manager.py
+++ b/eval_anything/utils/cache_manager.py
@@ -18,7 +18,6 @@ import time
 
 from eval_anything.utils.data_type import InferenceInput, InferenceOutput
 from eval_anything.utils.logger import EvalLogger
-from eval_anything.utils.utils import get_project_root
 
 class BinaryCache:
     """Binary cache implementation with support for multiple tensor types"""
@@ -96,10 +95,11 @@ class CacheManager:
         # Get all relevant inference parameters
         infer_params = []
         
-        for param in dir(infer_cfgs):
-            value = getattr(infer_cfgs, param)
+        # Get only the actual fields from the namedtuple
+        for field in infer_cfgs._fields:
+            value = getattr(infer_cfgs, field)
             if value is not None:
-                infer_params.append(f"{param}={value}")
+                infer_params.append(f"{field}={value}")
 
         # Append inference parameters to model name
         if infer_params:

--- a/eval_anything/utils/data_type.py
+++ b/eval_anything/utils/data_type.py
@@ -74,6 +74,7 @@ class InferenceInput:
 
     text: str
     mm_data: MultiModalData
+    metadata: dict = None
 
     def __init__(
         self,
@@ -82,12 +83,14 @@ class InferenceInput:
         urls: List[str] | str | None = None,
         data_files = None,
         ref_answer: str | None = None,
-        uuid: Dict[str, str] = None
+        uuid: Dict[str, str] = None,
+        metadata: dict = None
     ):
         self.task = task
         self.text = text
         self.uuid = uuid or {}
         self.ref_answer = ref_answer    # ground_truth
+        self.metadata = metadata or {}  # Store benchmark-specific data
 
         # FIXME: Decide data structure of urls
         if isinstance(urls, str):
@@ -113,7 +116,8 @@ class InferenceInput:
             "text": self.text,
             "urls": [mm_data.url for mm_data in self.mm_data],
             "ref_answer": self.ref_answer,
-            "uuid": self.uuid
+            "uuid": self.uuid,
+            "metadata": self.metadata
         }
 
 
@@ -196,7 +200,7 @@ class InferenceOutput:
             "task": self.task,
             "uuid": self.uuid,
             "response": self.response,
-            "engine": self.engine
+            "engine": self.engine,
         }
 
     # TODO

--- a/eval_anything/utils/utils.py
+++ b/eval_anything/utils/utils.py
@@ -6,9 +6,18 @@ from eval_anything.utils.data_type import ModalityType
 import os
 import json
 import yaml
-from typing import Any
+from typing import Any, Dict, Optional, Union, List
 from collections import namedtuple
 from pathlib import Path
+import numpy as np
+import contextlib
+import faulthandler
+import io
+import multiprocessing
+import platform
+import signal
+import tempfile
+import itertools 
 
 BENCHMARK_MODALITY_MAP = {
     'gsm8k': 'text_to_text',
@@ -75,6 +84,34 @@ class DialoguePromptBuilder():
         question = self.marge_QA(input)
         prompt = f"{context}{question}"
         return prompt
+
+class CodesGenerationPromptBuilder():
+    def __init__(self, few_shot_examples: Optional[list[str]] = None, cot_context: Optional[str] = None, cot: bool = False):
+        self.cot_context = cot_context if cot_context else "Let's think step by step."
+        self.few_shot_examples = few_shot_examples
+        self.enable_cot = cot
+        self.code_generation_prompt = 'The following are function description (with Canonical_solution).'
+
+    def build_example_prompt(self, question: str, ground_truth: str, with_answer=True):
+        answer = (
+            f'Canonical_solution: ```python\n{ground_truth}\n```'
+            if with_answer
+            else ''
+        )
+        return f"Function description: {question}\n{answer}"
+       
+    def build_prompt(self, question: str, ground_truth: str) -> str:
+        prompt = f"{self.code_generation_prompt}\n\n"
+        if self.few_shot_examples:
+            for question, ground_truth in zip(self.few_shot_examples['prompt'], self.few_shot_examples['canonical_solution']):
+                prompt += self.build_example_prompt(question, ground_truth)
+        
+        prompt += self.build_example_prompt(question, ground_truth, with_answer=False)
+        if self.enable_cot:
+            prompt += f"\n{self.cot_context}"
+        prompt += "\nPlease provide your solution in a code block using ```python\n...\n``` format."
+        return prompt
+
 
 
 class UUIDGenerator():
@@ -256,3 +293,261 @@ def get_project_root():
         if (parent / ".git").exists() or (parent / "pyproject.toml").exists():
             return parent
     return None
+
+def unsafe_execute(problem: Dict, completion: str, timeout: float, result):
+    with create_tempdir():
+
+        # These system calls are needed when cleaning up tempdir.
+        import os
+        import shutil
+
+        rmtree = shutil.rmtree
+        rmdir = os.rmdir
+        chdir = os.chdir
+
+        # Disable functionalities that can make destructive changes to the test.
+        reliability_guard()
+
+        # Construct the check program and run it.
+        check_program = (
+            completion
+            + "\n"
+            + problem["test"]
+            + "\n"
+            + f"check({problem['entry_point']})"
+        )
+
+        try:
+            exec_globals = {}
+            with swallow_io():
+                with time_limit(timeout):
+                    # WARNING
+                    # This program exists to execute untrusted model-generated code. Although
+                    # it is highly unlikely that model-generated code will do something overtly
+                    # malicious in response to this test suite, model-generated code may act
+                    # destructively due to a lack of model capability or alignment.
+                    # Users are strongly encouraged to sandbox this evaluation suite so that it
+                    # does not perform destructive actions on their host or network. For more
+                    # information on how OpenAI sandboxes its code, see the accompanying paper.
+                    # Once you have read this disclaimer and taken appropriate precautions,
+                    # uncomment the following line and proceed at your own risk:
+                    exec(check_program, exec_globals)
+            result.append("passed")
+        except TimeoutException:
+            result.append("timed out")
+        except BaseException as e:
+            result.append(f"failed: {e}")
+
+        # Needed for cleaning up.
+        shutil.rmtree = rmtree
+        os.rmdir = rmdir
+        os.chdir = chdir
+
+
+def check_correctness(
+    problem: Dict, completion: str, timeout: float, completion_id: Optional[int] = None
+) -> Dict:
+    """
+    Evaluates the functional correctness of a completion by running the test
+    suite provided in the problem.
+    """
+    # Set tokenizer parallelism before creating new process
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+    manager = multiprocessing.Manager()
+    result = manager.list()
+
+    def worker_init():
+        # Ensure child processes also have tokenizer parallelism disabled
+        os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+    p = multiprocessing.Process(target=unsafe_execute, args=(problem, completion, timeout, result))
+    p.start()
+    p.join(timeout=timeout + 1)
+    if p.is_alive():
+        p.kill()
+
+    if not result:
+        result.append("timed out")
+
+    return dict(
+        task_id=problem["task_id"],
+        passed=result[0] == "passed",
+        result=result[0],
+        completion_id=completion_id,
+    )
+
+
+@contextlib.contextmanager
+def time_limit(seconds: float):
+    def signal_handler(signum, frame):
+        raise TimeoutException("Timed out!")
+
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    signal.signal(signal.SIGALRM, signal_handler)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+
+
+@contextlib.contextmanager
+def swallow_io():
+    stream = WriteOnlyStringIO()
+    with contextlib.redirect_stdout(stream):
+        with contextlib.redirect_stderr(stream):
+            with redirect_stdin(stream):
+                yield
+
+
+@contextlib.contextmanager
+def create_tempdir():
+    with tempfile.TemporaryDirectory() as dirname:
+        with chdir(dirname):
+            yield dirname
+
+
+class TimeoutException(Exception):
+    pass
+
+
+class WriteOnlyStringIO(io.StringIO):
+    """StringIO that throws an exception when it's read from"""
+
+    def read(self, *args, **kwargs):
+        raise IOError
+
+    def readline(self, *args, **kwargs):
+        raise IOError
+
+    def readlines(self, *args, **kwargs):
+        raise IOError
+
+    def readable(self, *args, **kwargs):
+        """Returns True if the IO object can be read."""
+        return False
+
+
+class redirect_stdin(contextlib._RedirectStream):  # type: ignore
+    _stream = "stdin"
+
+
+@contextlib.contextmanager
+def chdir(root):
+    if root == ".":
+        yield
+        return
+    cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        yield
+    except BaseException as exc:
+        raise exc
+    finally:
+        os.chdir(cwd)
+
+
+def reliability_guard(maximum_memory_bytes: Optional[int] = None):
+    """
+    This disables various destructive functions and prevents the generated code
+    from interfering with the test (e.g. fork bomb, killing other processes,
+    removing filesystem files, etc.)
+
+    WARNING
+    This function is NOT a security sandbox. Untrusted code, including, model-
+    generated code, should not be blindly executed outside of one. See the
+    Codex paper for more information about OpenAI's code sandbox, and proceed
+    with caution.
+    """
+
+    if maximum_memory_bytes is not None:
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_AS, (maximum_memory_bytes, maximum_memory_bytes))
+        resource.setrlimit(resource.RLIMIT_DATA, (maximum_memory_bytes, maximum_memory_bytes))
+        if not platform.uname().system == "Darwin":
+            resource.setrlimit(resource.RLIMIT_STACK, (maximum_memory_bytes, maximum_memory_bytes))
+
+    faulthandler.disable()
+
+    import builtins
+
+    builtins.exit = None
+    builtins.quit = None
+
+    import os
+
+    os.environ["OMP_NUM_THREADS"] = "1"
+
+    os.kill = None
+    os.system = None
+    os.putenv = None
+    os.remove = None
+    os.removedirs = None
+    os.rmdir = None
+    os.fchdir = None
+    os.setuid = None
+    os.fork = None
+    os.forkpty = None
+    os.killpg = None
+    os.rename = None
+    os.renames = None
+    os.truncate = None
+    os.replace = None
+    os.unlink = None
+    os.fchmod = None
+    os.fchown = None
+    os.chmod = None
+    os.chown = None
+    os.chroot = None
+    os.fchdir = None
+    os.lchflags = None
+    os.lchmod = None
+    os.lchown = None
+    os.getcwd = None
+    os.chdir = None
+
+    import shutil
+
+    shutil.rmtree = None
+    shutil.move = None
+    shutil.chown = None
+
+    import subprocess
+
+    subprocess.Popen = None  # type: ignore
+
+    __builtins__["help"] = None
+
+    import sys
+
+    sys.modules["ipdb"] = None
+    sys.modules["joblib"] = None
+    sys.modules["resource"] = None
+    sys.modules["psutil"] = None
+    sys.modules["tkinter"] = None
+
+def estimate_pass_at_k(
+    num_samples: Union[int, List[int], np.ndarray],
+    num_correct: Union[List[int], np.ndarray],
+    k: int
+) -> np.ndarray:
+    """
+    Estimates pass@k of each problem and returns them in an array.
+    """
+
+    def estimator(n: int, c: int, k: int) -> float:
+        """
+        Calculates 1 - comb(n - c, k) / comb(n, k).
+        """
+        if n - c < k:
+            return 1.0
+        return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
+
+    if isinstance(num_samples, int):
+        num_samples_it = itertools.repeat(num_samples, len(num_correct))
+    else:
+        assert len(num_samples) == len(num_correct)
+        num_samples_it = iter(num_samples)
+
+    return np.array([estimator(int(n), int(c), k) for n, c in zip(num_samples_it, num_correct)])


### PR DESCRIPTION
- Currently only support _pass rate_ metric for HumanEval, i.e., _pass@1_. General _pass@k_  metric support needs pipeline to support multiple rounds of inference on the same inference input with arbitrarily different inference configurations.
- Fix `get_cache_path` bugs: Now use unique cache path for same model with different inference configurations.
- Fix argument passing problem in metric calculation functions.